### PR TITLE
Remove virtual server subnet comm statement

### DIFF
--- a/configuring-private-subnet.md
+++ b/configuring-private-subnet.md
@@ -79,14 +79,7 @@ You must route {{site.data.keyword.powerSys_notm}} private network subnets over 
 When you have cloud connections or VPNaaS configured, you can create private networks automatically by attaching private network subnet to cloud connections.
 However, when you need a private network communication between the two {{site.data.keyword.powerSys_notm}} instances and not from/to IBM Cloud network, you must open a [support ticket](/docs/power-iaas?topic=power-iaas-getting-help-and-support) against {{site.data.keyword.powerSys_notm}} to configure such private network configuration.
 
-For example, if you add a subnet *172.10.10.0/24* from user interface, and if this use case requires communication between the virtual server instances that are attached to the subnet, you must open a support ticket and provide the following subnet information that is displayed in the {{site.data.keyword.powerSys_notm}} user interface.
-
-| Name          |  Gateway     | VLAN ID | CIDR       |
-| ------------- |  ----------- | ------- | ---------- |
-| powerns-net02 |  172.10.10.1 | 3001    | 172.10.10.0/26 |
-{: caption="Table 1. Example subnet information displayed in UI" caption-side="bottom"}
-
-If your private subnets are routed over a Direct Link, you must also make sure that your {{site.data.keyword.powerSys_notm}} has a route to the {{site.data.keyword.cloud_notm}}. The default route might not be set up to route traffic to {{site.data.keyword.cloud_notm}} subnets, which are typically of the form, *10.xx.xx.xx*. Similarly, {{site.data.keyword.cloud_notm}} network-based x86 virtual switch interfaces (VSI) and other hosts might require an IP route to connect to a {{site.data.keyword.powerSys_notm}}.
+If your private subnets are routed over a Direct Link, you must make sure that your {{site.data.keyword.powerSys_notm}} has a route to the {{site.data.keyword.cloud_notm}}. The default route might not be set up to route traffic to {{site.data.keyword.cloud_notm}} subnets, which are typically of the form, *10.xx.xx.xx*. Similarly, {{site.data.keyword.cloud_notm}} network-based x86 virtual switch interfaces (VSI) and other hosts might require an IP route to connect to a {{site.data.keyword.powerSys_notm}}.
 
 The gateway for {{site.data.keyword.powerSys_notm}} is also the gateway for the local subnet that is routed to the {{site.data.keyword.cloud_notm}} over {{site.data.keyword.cloud_notm}} Direct Link. The {{site.data.keyword.cloud_notm}} x86 VSI might need a static route to {{site.data.keyword.powerSys_notm}} subnets as well. The gateway for this route is the same as the gateway for the {{site.data.keyword.cloud_notm}} private network.
 


### PR DESCRIPTION
Remove the outdated statement about needing a support ticket to allow VSI comm within a subnet.

Resolves: #80