### PR TITLE
Cloud connections automatically shared

### DIFF
--- a/cloud-connections-CLI.md
+++ b/cloud-connections-CLI.md
@@ -25,8 +25,6 @@ You can have a maximum of two {{site.data.keyword.cloud_notm}} ({{site.data.keyw
 ## Support for {{site.data.keyword.powerSys_notm}} workspaces with {{site.data.keyword.cloud_notm}} connections
 {: #powervs-support-cloud-connections}
 
-{{site.data.keyword.powerSys_notm}} supports multiple workspaces from the same account. However, any given {{site.data.keyword.cloud_notm}} connection can be used by only one workspace. If you want to configure a setup with multiple workspaces for the same account and if you want these workspaces to share an {{site.data.keyword.cloud_notm}} connection, open an [IBM Support case](/docs/power-iaas?topic=power-iaas-getting-help-and-support).
-
 When you perform multiple {{site.data.keyword.cloud_notm}} connection tasks, actions within a task can time out. When the timeout occurs, the tasks are completed in the background and the status might not change immediately.
 {: note}
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -53,7 +53,7 @@ Before you create your first Power Systems Virtual Server instance, review the f
 
 4. *(Optional)* If you want to use a custom AIX or IBM i image, you must create an IBM Cloud Object Storage (COS) and upload it there. For more information, see [Deploying a custom image within a Power Systems Virtual Server](/docs/power-iaas?topic=power-iaas-deploy-custom-image).
 
-5. *(Optional)* If you want to use a private network to connect to a {{site.data.keyword.powerSys_notm}} instance, you must either create cloud connections, see see [Managing Cloud connections](/docs/power-iaas?topic=power-iaas-cloud-connections), or order the [Direct Link Connect](/docs/power-iaas?topic=power-iaas-ordering-direct-link-connect#steps-to-order-direct-link-connect) service. You cannot create a private network during the VM provisioning process. You must first use the {{site.data.keyword.powerSys_notm}} user interface, command line interface (CLI), or application programming interfaced (API) to [create one](/docs/power-iaas?topic=power-iaas-configuring-subnet).
+5. *(Optional)* If you want to use a private network to connect to a {{site.data.keyword.powerSys_notm}} instance, you must order the [Direct Link Connect](/docs/power-iaas?topic=power-iaas-ordering-direct-link-connect#steps-to-order-direct-link-connect) service. You cannot create a private network during the VM provisioning process. You must first use the {{site.data.keyword.powerSys_notm}} user interface, command line interface (CLI), or application programming interfaced (API) to [create one](/docs/power-iaas?topic=power-iaas-configuring-subnet).
 
 ## Next steps
 {: #next-steps}

--- a/getting-started.md
+++ b/getting-started.md
@@ -53,7 +53,7 @@ Before you create your first Power Systems Virtual Server instance, review the f
 
 4. *(Optional)* If you want to use a custom AIX or IBM i image, you must create an IBM Cloud Object Storage (COS) and upload it there. For more information, see [Deploying a custom image within a Power Systems Virtual Server](/docs/power-iaas?topic=power-iaas-deploy-custom-image).
 
-5. *(Optional)* If you want to use a private network to connect to a {{site.data.keyword.powerSys_notm}} instance, you must order the [Direct Link Connect](/docs/power-iaas?topic=power-iaas-ordering-direct-link-connect#steps-to-order-direct-link-connect) service. You cannot create a private network during the VM provisioning process. You must first use the {{site.data.keyword.powerSys_notm}} user interface, command line interface (CLI), or application programming interfaced (API) to [create one](/docs/power-iaas?topic=power-iaas-configuring-subnet).
+5. *(Optional)* If you want to use a private network to connect to a {{site.data.keyword.powerSys_notm}} instance, you must either create cloud connections, see see [Managing Cloud connections](/docs/power-iaas?topic=power-iaas-cloud-connections), or order the [Direct Link Connect](/docs/power-iaas?topic=power-iaas-ordering-direct-link-connect#steps-to-order-direct-link-connect) service. You cannot create a private network during the VM provisioning process. You must first use the {{site.data.keyword.powerSys_notm}} user interface, command line interface (CLI), or application programming interfaced (API) to [create one](/docs/power-iaas?topic=power-iaas-configuring-subnet).
 
 ## Next steps
 {: #next-steps}


### PR DESCRIPTION
Remove statement about a support case required for sharing cloud connections between workspaces.

Resolves: #84 