### PR TITLE
Update private net conn to reference cloud connections

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -53,7 +53,7 @@ Before you create your first Power Systems Virtual Server instance, review the f
 
 4. *(Optional)* If you want to use a custom AIX or IBM i image, you must create an IBM Cloud Object Storage (COS) and upload it there. For more information, see [Deploying a custom image within a Power Systems Virtual Server](/docs/power-iaas?topic=power-iaas-deploy-custom-image).
 
-5. *(Optional)* If you want to use a private network to connect to a {{site.data.keyword.powerSys_notm}} instance, you must order the [Direct Link Connect](/docs/power-iaas?topic=power-iaas-ordering-direct-link-connect#steps-to-order-direct-link-connect) service. You cannot create a private network during the VM provisioning process. You must first use the {{site.data.keyword.powerSys_notm}} user interface, command line interface (CLI), or application programming interfaced (API) to [create one](/docs/power-iaas?topic=power-iaas-configuring-subnet).
+5. *(Optional)* If you want to use a private network to connect to a {{site.data.keyword.powerSys_notm}} instance, you must either create cloud connections, see see [Managing Cloud connections](/docs/power-iaas?topic=power-iaas-cloud-connections), or order the [Direct Link Connect](/docs/power-iaas?topic=power-iaas-ordering-direct-link-connect#steps-to-order-direct-link-connect) service. You cannot create a private network during the VM provisioning process. You must first use the {{site.data.keyword.powerSys_notm}} user interface, command line interface (CLI), or application programming interfaced (API) to [create one](/docs/power-iaas?topic=power-iaas-configuring-subnet).
 
 ## Next steps
 {: #next-steps}


### PR DESCRIPTION
Update the Getting Started optional private network connection steps to link to IBM Cloud connections before
Direct Link provisioning.

Resolves: #82 